### PR TITLE
Change CloudFormation parmeter SplunkAPIKey to SplunkAccessToken

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -60,7 +60,7 @@ You will find detailed output in taskcat_outputs.
 Quick link, when opened in AWS console, will present you with a form to deploy a template which you passed as a parameter.
 
 The quick link format is:
-`https://console.aws.amazon.com/cloudformation/home?region=<region>#/stacks/create/review?templateURL=<templateUrl>&param_IntegrationId=<integrationId>&param_SplunkAPIKey=<accessKey>&param_SplunkLogIngestUrl=<logIngestUrl>&param_SplunkMetricIngestUrl=<metricIngestUrl>`
+`https://console.aws.amazon.com/cloudformation/home?region=<region>#/stacks/create/review?templateURL=<templateUrl>&param_SplunkAccessToken=<accessKey>&param_SplunkIngestUrl=<ingestUrl>`
 
 For example, if you wish to check how the published template in eu-central-1 works, login to AWS console where you want to deploy and go to:
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ There is no hosted deployment package in AWS China and Gov regions, so prior to 
 ### Template parameters
 |Parameter |Value |
 | ---------|:-------------|
-| SplunkAPIKey | the Access Token from your Splunk Observability organization   |
+| SplunkAccessToken | the Access Token from your Splunk Observability organization   |
 | SplunkIngestUrl | Real-time Data Ingest url from your account. In our example, the value would be `https://ingest.us0.signalfx.com`. Splunk uses this to ingest logs, metrics and to monitor the usage and adoption of aws-collector-lambda.   |
 | UseHostedLambdaDeploymentPackage | Change this to false if you want to use .zip archive hosted in your S3 bucket. You need to do this in Gov and China.   |
 | LambdaDeploymentPackageS3Bucket | The name of S3 bucket where you host .zip archive with Lambda code. For example, if the ARN of your archive is `arn:aws:s3:::my-bucket/my-folder/aws-log-collector.zip`, the value of this parameter is `my-bucket`. You need to pass this parameter in Gov and China.  |

--- a/latest/template_all_features.yaml
+++ b/latest/template_all_features.yaml
@@ -4,7 +4,7 @@ AWSTemplateFormatVersion: '2010-09-09'
 Description: Splunk Logs and Metric Streams Integration
 
 Parameters:
-  SplunkAPIKey:
+  SplunkAccessToken:
     Type: String
     NoEcho: true
     Description: "Splunk Observability Access Token. You should have copied it in the previous step from the integration configuration. You can also find it in Organization Settings --> Access Tokens."
@@ -22,11 +22,11 @@ Metadata:
         Label:
           default: Required Parameters
         Parameters:
-          - SplunkAPIKey
+          - SplunkAccessToken
           - EnabledRegions
           - SplunkIngestUrl
     ParameterLabels:
-      SplunkAPIKey:
+      SplunkAccessToken:
         default: "Access Token"
       EnabledRegions:
         default: "Regions to deploy to"
@@ -49,8 +49,8 @@ Resources:
               - !Ref "AWS::AccountId"
           Regions: !Ref EnabledRegions
       Parameters:
-        - ParameterKey: SplunkAPIKey
-          ParameterValue: !Ref SplunkAPIKey
+        - ParameterKey: SplunkAccessToken
+          ParameterValue: !Ref SplunkAccessToken
         - ParameterKey: SplunkIngestUrl
           ParameterValue: !Ref SplunkIngestUrl
       TemplateURL: https://o11y-public.s3.amazonaws.com/aws-cloudformation-templates/test/template_logs_regional.yaml
@@ -69,8 +69,8 @@ Resources:
               - !Ref "AWS::AccountId"
           Regions: !Ref EnabledRegions
       Parameters:
-        - ParameterKey: SplunkAPIKey
-          ParameterValue: !Ref SplunkAPIKey
+        - ParameterKey: SplunkAccessToken
+          ParameterValue: !Ref SplunkAccessToken
         - ParameterKey: SplunkIngestUrl
           ParameterValue: !Ref SplunkIngestUrl
       TemplateURL: https://o11y-public.s3.amazonaws.com/aws-cloudformation-templates/test/template_metric_streams_regional.yaml

--- a/latest/template_all_features_regional.yaml
+++ b/latest/template_all_features_regional.yaml
@@ -5,7 +5,7 @@ AWSTemplateFormatVersion: '2010-09-09'
 Description: Regional resources required by Splunk AWS integration with CloudWatch Metric Streams and logs collection
 
 Parameters:
-  SplunkAPIKey:
+  SplunkAccessToken:
     Type: String
     NoEcho: true
     Description: "Splunk Observability Access Token. You should have copied it in the previous step from the integration configuration. You can also find it in Organization Settings --> Access Tokens."
@@ -32,7 +32,7 @@ Metadata:
         Label:
           default: Required Parameters
         Parameters:
-          - SplunkAPIKey
+          - SplunkAccessToken
           - SplunkIngestUrl
       -
         Label:
@@ -42,7 +42,7 @@ Metadata:
           - LambdaDeploymentPackageS3Bucket
           - LambdaDeploymentPackageS3Key
     ParameterLabels:
-      SplunkAPIKey:
+      SplunkAccessToken:
         default: "Access Token"
       SplunkIngestUrl:
         default: "Real-time Data Ingest endpoint"
@@ -59,8 +59,8 @@ Resources:
     Properties:
       TemplateURL: https://o11y-public.s3.amazonaws.com/aws-cloudformation-templates/test/template_logs_regional.yaml
       Parameters:
-        - ParameterKey: SplunkAPIKey
-          ParameterValue: !Ref SplunkAPIKey
+        - ParameterKey: SplunkAccessToken
+          ParameterValue: !Ref SplunkAccessToken
         - ParameterKey: SplunkIngestUrl
           ParameterValue: !Ref SplunkIngestUrl
         - ParameterKey: LambdaDeploymentPackageS3Bucket
@@ -74,7 +74,7 @@ Resources:
     Properties:
       TemplateURL: https://o11y-public.s3.amazonaws.com/aws-cloudformation-templates/test/template_metric_streams_regional.yaml
       Parameters:
-        - ParameterKey: SplunkAPIKey
-          ParameterValue: !Ref SplunkAPIKey
+        - ParameterKey: SplunkAccessToken
+          ParameterValue: !Ref SplunkAccessToken
         - ParameterKey: SplunkIngestUrl
           ParameterValue: !Ref SplunkIngestUrl

--- a/logs/template_logs.yaml
+++ b/logs/template_logs.yaml
@@ -4,7 +4,7 @@ AWSTemplateFormatVersion: '2010-09-09'
 Description: Splunk Logs Integration
 
 Parameters:
-  SplunkAPIKey:
+  SplunkAccessToken:
     Type: String
     NoEcho: true
     Description: "Splunk Observability Access Token. You should have copied it in the previous step from the integration configuration. You can also find it in Organization Settings --> Access Tokens."
@@ -22,11 +22,11 @@ Metadata:
         Label:
           default: Required Parameters
         Parameters:
-          - SplunkAPIKey
+          - SplunkAccessToken
           - SplunkIngestUrl
           - EnabledRegions
     ParameterLabels:
-      SplunkAPIKey:
+      SplunkAccessToken:
         default: "Access Token"
       SplunkIngestUrl:
         default: "Real-time Data Ingest endpoint"
@@ -48,8 +48,8 @@ Resources:
               - !Ref "AWS::AccountId"
           Regions: !Ref EnabledRegions
       Parameters:
-        - ParameterKey: SplunkAPIKey
-          ParameterValue: !Ref SplunkAPIKey
+        - ParameterKey: SplunkAccessToken
+          ParameterValue: !Ref SplunkAccessToken
         - ParameterKey: SplunkIngestUrl
           ParameterValue: !Ref SplunkIngestUrl
       TemplateURL: https://o11y-public.s3.amazonaws.com/aws-cloudformation-templates/test/template_logs_regional.yaml

--- a/logs/template_logs_regional.yaml
+++ b/logs/template_logs_regional.yaml
@@ -4,7 +4,7 @@ AWSTemplateFormatVersion: '2010-09-09'
 Description: Splunk AWS Logs Collector lambda and permissions
 
 Parameters:
-  SplunkAPIKey:
+  SplunkAccessToken:
     Type: String
     NoEcho: true
     Description: "Splunk Observability Access Token. You should have copied it in the previous step from the integration configuration. You can also find it in Organization Settings --> Access Tokens."
@@ -31,7 +31,7 @@ Metadata:
         Label:
           default: Required Parameters
         Parameters:
-          - SplunkAPIKey
+          - SplunkAccessToken
           - SplunkIngestUrl
       -
         Label:
@@ -41,7 +41,7 @@ Metadata:
           - LambdaDeploymentPackageS3Bucket
           - LambdaDeploymentPackageS3Key
     ParameterLabels:
-      SplunkAPIKey:
+      SplunkAccessToken:
         default: "Access Token"
       SplunkIngestUrl:
         default: "Real-time Data Ingest endpoint"
@@ -104,7 +104,7 @@ Resources:
       Handler: function.lambda_handler
       Environment:
         Variables:
-          SPLUNK_API_KEY: !Ref SplunkAPIKey
+          SPLUNK_API_KEY: !Ref SplunkAccessToken
           SPLUNK_LOG_URL: !Sub '${SplunkIngestUrl}/v1/log'
           SPLUNK_METRIC_URL: !Ref SplunkIngestUrl
       Role: !GetAtt SplunkAwsLogsCollectorRole.Arn

--- a/metric-streams-beta/template_metric_streams.yaml
+++ b/metric-streams-beta/template_metric_streams.yaml
@@ -4,7 +4,7 @@ AWSTemplateFormatVersion: '2010-09-09'
 Description: Splunk Metric Streams Integration
 
 Parameters:
-  SplunkAPIKey:
+  SplunkAccessToken:
     Type: String
     NoEcho: true
     Description: "Splunk Observability Access Token. You should have copied it in the previous step from the integration configuration. You can also find it in Organization Settings --> Access Tokens."
@@ -22,11 +22,11 @@ Metadata:
         Label:
           default: Required Parameters
         Parameters:
-          - SplunkAPIKey
+          - SplunkAccessToken
           - EnabledRegions
           - SplunkIngestUrl
     ParameterLabels:
-      SplunkAPIKey:
+      SplunkAccessToken:
         default: "Access Token"
       EnabledRegions:
         default: "Regions to deploy to"
@@ -49,8 +49,8 @@ Resources:
               - !Ref "AWS::AccountId"
           Regions: !Ref EnabledRegions
       Parameters:
-        - ParameterKey: SplunkAPIKey
-          ParameterValue: !Ref SplunkAPIKey
+        - ParameterKey: SplunkAccessToken
+          ParameterValue: !Ref SplunkAccessToken
         - ParameterKey: SplunkIngestUrl
           ParameterValue: !Ref SplunkIngestUrl
       TemplateURL: https://o11y-public.s3.amazonaws.com/aws-cloudformation-templates/test/template_metric_streams_regional.yaml

--- a/metric-streams-beta/template_metric_streams_regional.yaml
+++ b/metric-streams-beta/template_metric_streams_regional.yaml
@@ -4,7 +4,7 @@ AWSTemplateFormatVersion: '2010-09-09'
 Description: Regional resources for Splunk AWS Metric Streams Integration.
 
 Parameters:
-  SplunkAPIKey:
+  SplunkAccessToken:
     Type: String
     NoEcho: true
     Description: "Splunk Observability Access Token. You should have copied it in the previous step from the integration configuration. You can also find it in Organization Settings --> Access Tokens."
@@ -19,10 +19,10 @@ Metadata:
         Label:
           default: Required Parameters
         Parameters:
-          - SplunkAPIKey
+          - SplunkAccessToken
           - SplunkIngestUrl
     ParameterLabels:
-      SplunkAPIKey:
+      SplunkAccessToken:
         default: "Access Token"
       SplunkIngestUrl:
         default: "Real-time Data Ingest endpoint"
@@ -107,7 +107,7 @@ Resources:
           IntervalInSeconds: 60
           SizeInMBs: 1
         EndpointConfiguration:
-          AccessKey: !Ref SplunkAPIKey
+          AccessKey: !Ref SplunkAccessToken
           Url: !Sub '${SplunkIngestUrl}/v1/cloudwatch_metric_stream'
         RequestConfiguration:
           ContentEncoding: GZIP


### PR DESCRIPTION
Change CloudFormation parmeter SplunkAPIKey to SplunkAccessToken to match GDI conventions.