### PR TITLE
Downgrade log collector runtime to python 3.11

### DIFF
--- a/logs/template_logs_regional.yaml
+++ b/logs/template_logs_regional.yaml
@@ -125,7 +125,7 @@ Resources:
     Properties:
       Description: Splunk AWS Log Collector
       FunctionName: 'splunk-aws-logs-collector'
-      Runtime: python3.12
+      Runtime: python3.11
       Timeout: 60
       Code:
         S3Bucket: !If [UseHostedDeploymentPackageCondition, !Sub 'o11y-public-${AWS::Region}', !Ref LambdaDeploymentPackageS3Bucket ]


### PR DESCRIPTION
This is due to the AWS SDK issue:
https://github.com/aws/aws-cli/issues/8342