### PR TITLE
Update URL to correct packaged regional version in YAML template

### DIFF
--- a/metric-streams/template_metric_streams_regional.yaml
+++ b/metric-streams/template_metric_streams_regional.yaml
@@ -1,5 +1,5 @@
 #====== DO NOT DEPLOY THIS FILE. =======================================================================================
-#====== USE PACKAGED VERSION https://o11y-public.s3.amazonaws.com/aws-cloudformation-templates/release/template_metric_streams.yaml
+#====== USE PACKAGED VERSION https://o11y-public.s3.amazonaws.com/aws-cloudformation-templates/release/template_metric_streams_regional.yaml
 AWSTemplateFormatVersion: '2010-09-09'
 Description: Regional resources for Splunk AWS Metric Streams Integration.
 


### PR DESCRIPTION
The existing url was to the hosted prepackaged stackset config. 
Corrected it to the URL for the hosted prepackaged regional config.